### PR TITLE
Added breadcrumbs

### DIFF
--- a/templates/addModules.html
+++ b/templates/addModules.html
@@ -1,5 +1,9 @@
 $ title_string = 'Add Module'
 $var title:$title_string
+$ home = ['/', 'Home']
+$ addModule = ['#', 'Add Module']
+
+$var hierarchy = [home, addModule]
 
 <div class="container-fluid">
     <div class="row">

--- a/templates/base.html
+++ b/templates/base.html
@@ -98,7 +98,15 @@ $def with (page)
 					<!--li><a href="#">Module Timeline</a></li-->
 				</ul>
 			</div>
-
+			<div class="container">
+				<ol class="breadcrumb">
+					$for entry in page.hierarchy:
+						$if entry[0] != '#':
+							<li><a href='$entry[0]'>$entry[1]</a></li>
+						$else:
+							<li class='active'>$entry[1]</li>
+				</ol>
+			</div>
 			$:page
 
 	</body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,6 @@
 $var title:Home
+$ home = ['#', 'Home']
+$var hierarchy = [home]
 
 <h1 class="text-center"><b>Welcome to CSModify</b></h1>
 <br>

--- a/templates/individualModuleInfo.html
+++ b/templates/individualModuleInfo.html
@@ -9,6 +9,12 @@ $ overviewURL = '/viewModule'
 $ title_string = 'Module Info for ' + moduleCode + ' in ' + aySem
 
 $var title:$title_string
+$ home = ['/', 'Home']
+$ moduleInfo = ['/modules', 'Module Information']
+$ viewModule = ['/viewModule?code=' + moduleCode, moduleCode]
+$ individualModuleInfo = ['#' + aySem, 'Module Info for ' + aySem]
+
+$var hierarchy = [home, moduleInfo, viewModule, individualModuleInfo]
 
 <div class="container-fluid">
 	<div class="row">

--- a/templates/individualModuleInfo.html
+++ b/templates/individualModuleInfo.html
@@ -12,7 +12,7 @@ $var title:$title_string
 $ home = ['/', 'Home']
 $ moduleInfo = ['/modules', 'Module Information']
 $ viewModule = ['/viewModule?code=' + moduleCode, moduleCode]
-$ individualModuleInfo = ['#' + aySem, 'Module Info for ' + aySem]
+$ individualModuleInfo = ['#', 'Module Info for ' + aySem]
 
 $var hierarchy = [home, moduleInfo, viewModule, individualModuleInfo]
 

--- a/templates/moduleEdit.html
+++ b/templates/moduleEdit.html
@@ -8,7 +8,12 @@ $ moduleMC = moduleInfo[3]
 $ title_string = 'Editing ' + moduleCode
 
 $var title:$title_string
+$ home = ['/', 'Home']
+$ moduleInformation = ['/modules', 'Module Information']
+$ viewModule = ['/viewModule?code=' + moduleCode, moduleCode]
+$ editModule = ['#', 'Edit: ' + moduleCode]
 
+$var hierarchy = [home, moduleInformation, viewModule, editModule]
 
 <body>
     <div class="container-block container">

--- a/templates/moduleListing.html
+++ b/templates/moduleListing.html
@@ -1,6 +1,9 @@
 $def with (moduleInfos) 
 
 $var title:Module Information
+$ home = ['/', 'Home']
+$ moduleInfo = ['#', 'Module Information']
+$var hierarchy = [home, moduleInfo]
 
 <div class="container-fluid">
     <div class="row">

--- a/templates/moduleModified.html
+++ b/templates/moduleModified.html
@@ -2,8 +2,19 @@ $def with (modify_type, modifiedModulesSummary, modifiedModulesMounting, modifie
 
 $var title:View Modified Modules
 $ home = ['/', 'Home']
-$ modifiedModule = ['#', 'Modified Modules']
-$var hierarchy = [home, modifiedModule]
+$ modifiedModulePage = ['#', 'Modified Modules']
+$ modifiedModuleLink = ['/modifiedModules', 'Modified Modules']
+$if modify_type == "mounting":
+    $ modifyType = ['#', 'Modified Mounting of ' + targetModuleCode]
+    $var hierarchy = [home, modifiedModuleLink, modifyType]
+$elif modify_type == "quota":
+    $ modifyType = ['#', 'Modified Quota of ' + targetModuleCode]
+    $var hierarchy = [home, modifiedModuleLink, modifyType]
+$elif modify_type == "moduleDetails":
+    $ modifyType = ['#', 'Modified Module Details of ' + targetModuleCode]
+    $var hierarchy = [home, modifiedModuleLink, modifyType]
+$else:
+    $var hierarchy = [home, modifiedModulePage]
 
 <div class="container-fluid">
     <div class="row">

--- a/templates/moduleModified.html
+++ b/templates/moduleModified.html
@@ -1,6 +1,9 @@
 $def with (modify_type, modifiedModulesSummary, modifiedModulesMounting, modifiedModulesQuota, modifiedModulesDetails, targetModuleCode, targetModuleModifiedInfo)
 
-$var title:View modified modules
+$var title:View Modified Modules
+$ home = ['/', 'Home']
+$ modifiedModule = ['#', 'Modified Modules']
+$var hierarchy = [home, modifiedModule]
 
 <div class="container-fluid">
     <div class="row">

--- a/templates/moduleMountingFixed.html
+++ b/templates/moduleMountingFixed.html
@@ -2,7 +2,9 @@ $def with (currentAY, fullMountingPlan)
 
 $ title_string = 'Fixed Module Mounting In ' + currentAY
 $var title:$title_string
-
+$ home = ['/', 'Home']
+$ fixedMounting = ['#', title_string]
+$var hierarchy = [home, fixedMounting]
 <div class="container-fluid">
     <div class="row">
         <div class="col-md-12">

--- a/templates/moduleMountingTentative.html
+++ b/templates/moduleMountingTentative.html
@@ -3,6 +3,10 @@ $def with (selectedAY, fullMountingPlan)
 $ title_string = 'Tentative Module Mounting In ' + selectedAY
 
 $var title:$title_string
+$ home = ['/', 'Home']
+$ tentativeMounting = ['#', title_string]
+
+$var hierarchy = [home, tentativeMounting]
 
 <div class="container-fluid">
     <div class="row">

--- a/templates/modulesTakenPriorToInternship.html
+++ b/templates/modulesTakenPriorToInternship.html
@@ -1,6 +1,9 @@
 $def with (moduleListWithCount, list_of_ay_sems, ay_sem)
 
 $var title:View Modules Taken Prior to Internship
+$ home = ['/', 'Home']
+$ modulesPriorIntern = ['#', 'Modules Taken Prior to Internship']
+$var hierarchy = [home, modulesPriorIntern]
 
 <div class="container-fluid">
 	<h1 class="text-center"><b>Modules Taken Prior to Internship for $ay_sem</b></h1>

--- a/templates/modulesTakenPriorToOthers.html
+++ b/templates/modulesTakenPriorToOthers.html
@@ -2,7 +2,7 @@ $def with (modulePairs, allAySems, studentCounts, studentPriorCount, moduleA, mo
 
 $var title:View Modules Taken Prior to Others
 $ home = ['/', 'Home']
-$ modulesPriorOthers = ['#', 'Modules Taken Prior to Others']
+$ modulesPriorOthers = ['#', 'Modules Taken Prior to Other Modules']
 
 $var hierarchy = [home, modulesPriorOthers]
 

--- a/templates/modulesTakenPriorToOthers.html
+++ b/templates/modulesTakenPriorToOthers.html
@@ -1,6 +1,10 @@
 $def with (modulePairs, allAySems, studentCounts, studentPriorCount, moduleA, moduleB, targetAySem, studentsInModuleB)
 
 $var title:View Modules Taken Prior to Others
+$ home = ['/', 'Home']
+$ modulesPriorOthers = ['#', 'Modules Taken Prior to Others']
+
+$var hierarchy = [home, modulesPriorOthers]
 
 $if modulePairs is not None:
 	<div class="container-fluid">

--- a/templates/mountingEdit.html
+++ b/templates/mountingEdit.html
@@ -3,6 +3,12 @@ $def with (moduleCode, aySem, mountingValue, quota, overlappingList)
 $ title_string = 'Editing ' + moduleCode + ' for ' + aySem
 
 $var title:$title_string
+$ home = ['/', 'Home']
+$ moduleInfo = ['/modules', 'Module Information']
+$ viewModule = ['/viewModule?code=' + moduleCode, moduleCode]
+$ individualModuleInfo = ['/individualModuleInfo?code=' + moduleCode + '&amp;targetAY=' + aySem, 'Module Info for ' + aySem]
+$ editIndividualModule = ['#', title_string]
+$var hierarchy = [home, moduleInfo, viewModule, individualModuleInfo, editIndividualModule]
 
 <body>
     <div class="container-block container">

--- a/templates/nonOverlappingModules.html
+++ b/templates/nonOverlappingModules.html
@@ -1,6 +1,10 @@
 $def with (lst_of_independ_mods, lst_of_ay_sem, ay_sem)
 
 $var title:Non-Overlapping Modules
+$ home = ['/', 'Home']
+$ nonOverlap = ['#', 'Non-Overlapping Modules']
+
+$var hierarchy = [home, nonOverlap]
 
 <div class="container container-fluid">
     <div class="row">

--- a/templates/overlappingModules.html
+++ b/templates/overlappingModules.html
@@ -3,6 +3,10 @@ $def with (lst_of_mods)
 $ page_title = "Modules Taken Together In The Same Semester"
 
 $var title:$page_title
+$ home = ['/', 'Home']
+$ overlapModules = ['#', 'Overlapping Modules']
+
+$var hierarchy = [home, overlapModules]
 
 <div class="container-fluid">
     <div class="row">

--- a/templates/oversubscribedModules.html
+++ b/templates/oversubscribedModules.html
@@ -1,7 +1,10 @@
 $def with (list_of_oversub_mod)
 
 $var title:View Oversubscribed Modules
+$ home = ['/', 'Home']
+$ oversubscribedModules = ['#', 'Oversubscribed Modules']
 
+$var hierarchy = [home, oversubscribedModules]
 <div class="container-fluid">
 	<h1 class="text-center"><b>Oversubscribed Modules</b></h1>
 	<p class="text-center">Shows all modules with <b>demand &gt; supply</b></p>

--- a/templates/studentEnrollment.html
+++ b/templates/studentEnrollment.html
@@ -1,6 +1,10 @@
 $def with (yr_of_study_count_table, focus_count_table)
 
 $var title:View Student Enrollment
+$ home = ['/', 'Home']
+$ enrolInfo = ['#', 'Student Enrollment Information']
+
+$var hierarchy = [home, enrolInfo]
 
 <div class="container-fluid">
 	<h1 class="text-center"><b>Student Enrollment Information</b></h1>

--- a/templates/studentsAffectedByModule.html
+++ b/templates/studentsAffectedByModule.html
@@ -1,10 +1,17 @@
-$def with (code, ay_sem, student_lst)
+$def with (moduleCode, aySem, student_lst)
 $ title_string = 'Students Affected By Module Changes'
 $var title:$title_string
+$ home = ['/', 'Home']
+$ moduleInfo = ['/modules', 'Module Information']
+$ viewModule = ['/viewModule?code=' + moduleCode, moduleCode]
+$ individualModuleInfo = ['/individualModuleInfo?code=' + moduleCode + '&amp;targetAY=' + aySem, 'Module Info for ' + aySem]
+$ affectedStudents = ['#', title_string]
+
+$var hierarchy = [home, moduleInfo, viewModule, individualModuleInfo, affectedStudents]
 
 <div class="container container-block">
     <h1 class="text-center">Students Affected By Module Changes</h1>
-    <h3 class="text-center">For <b>$code</b> in <b>$ay_sem</b></h3>
+    <h3 class="text-center">For <b>$moduleCode</b> in <b>$aySem</b></h3>
     <table id="students-taking-module-table" class="table table-bordered table-hover display dataTable">
         <thead>
             <tr>

--- a/templates/viewModule.html
+++ b/templates/viewModule.html
@@ -17,6 +17,10 @@ $code:
 $ title_string = 'View Info for ' + moduleCode
 
 $var title:$title_string
+$ home = ['/', 'Home']
+$ moduleInfo = ['/modules', 'Module Information']
+$ viewModule = ['#', moduleCode]
+$var hierarchy = [home, moduleInfo, viewModule]
 
 <!--bottom half module info-->
 <div class="container-fluid">


### PR DESCRIPTION
Breadcrumbs are added!
As per discussion, fixed hierarchy,
i.e. accessing CP3200 from modified modules page will still have breadcrumbs Home/Module Listing/CP3200

Also with 3 possible styles (and more!) (for discussion):
![image](https://cloud.githubusercontent.com/assets/12347266/24074886/90ccde0a-0c4c-11e7-8c48-19f0e9fdddfb.png)
