### PR TITLE
Merge deleteModule into integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ URLS = (
     '/viewModule', 'components.handlers.module_overview.ViewMod',
     '/flagAsRemoved/(.*)', 'components.handlers.module_listing.FlagAsRemoved',
     '/flagAsActive/(.*)', 'components.handlers.module_listing.FlagAsActive',
-    '/deleteModule/(.*)', 'components.handlers.module_listing.DeleteMod',
+    '/deleteModule', 'components.handlers.delete_module.DeleteMod',
     '/editModule', 'components.handlers.module_edit.EditModuleInfo',
     '/editMounting', 'components.handlers.module_edit.EditMountingInfo',
     '/individualModuleInfo', 'components.handlers.module_view_in_ay_sem.IndividualModule',

--- a/components/database.py
+++ b/components/database.py
@@ -77,6 +77,15 @@ def get_original_module_info(code):
     return DB_CURSOR.fetchone()
 
 
+def get_new_modules():
+    '''
+        Get the module code, name, description and MCs of modules with status 'New'
+    '''
+    sql_command = "SELECT * FROM module WHERE status='New'"
+    DB_CURSOR.execute(sql_command)
+    return DB_CURSOR.fetchall()
+
+
 ######################################################################################
 # Functions that add/modify/delete general module information
 ######################################################################################

--- a/components/handlers/delete_module.py
+++ b/components/handlers/delete_module.py
@@ -45,4 +45,12 @@ class DeleteMod(object):
 
         else:
             outcome = model.delete_module(module_code)
-            return Outcome().POST("delete_module", outcome, module_code)
+            if outcome is False:
+                tenta_mounted_modules = model.get_all_tenta_mounted_modules()
+                tenta_mounted_module_codes = [module[0] for module in tenta_mounted_modules]
+                if module_code in tenta_mounted_module_codes:
+                    return Outcome().POST("delete_module", "has_mounting", module_code)
+                else:
+                    return Outcome().POST("delete_module", "is_starred", module_code)
+            else:
+                return Outcome().POST("delete_module", True, module_code)

--- a/components/handlers/delete_module.py
+++ b/components/handlers/delete_module.py
@@ -1,0 +1,48 @@
+'''
+    This module contains the handler for web requests pertaining to
+    the Delete Module page.
+'''
+
+
+from app import RENDER
+import web
+from components import model, session
+from components.handlers.outcome import Outcome
+
+
+class DeleteMod(object):
+    '''
+        This class handles the display of the Delete Module page
+        and the deletion of a module
+    '''
+    def GET(self):
+        '''
+            Handles the display of the Delete Module page
+        '''
+        if not session.validate_session():
+            raise web.seeother('/login')
+        else:
+            module_infos = model.get_new_modules()
+            return RENDER.deleteModule(module_infos)
+
+
+    def POST(self):
+        '''
+            Handles the deletion of a module
+        '''
+        # Verify that module exists
+        input_data = model.validate_input(web.input(), ["code"], show_404=False)
+        try:
+            module_code = input_data.code
+        except AttributeError:
+            return Outcome().POST("delete_module", False, None)
+
+        # Verify that module's status is 'New'
+        module_infos = model.get_new_modules()
+        new_modules = [module_info[0] for module_info in module_infos]
+        if module_code not in new_modules:
+            return Outcome().POST("delete_module", False, None)
+
+        else:
+            outcome = model.delete_module(module_code)
+            return Outcome().POST("delete_module", outcome, module_code)

--- a/components/handlers/module_listing.py
+++ b/components/handlers/module_listing.py
@@ -7,12 +7,11 @@
 from app import RENDER
 import web
 from components import model, session
-from components.handlers.outcome import Outcome
 
 
 class Modules(object):
     '''
-        This class handles the 'Add Module' form and the displaying of list of modules
+        This class handles the display of the full list of modules and their information
     '''
     URL_THIS_PAGE = '/modules'
 
@@ -33,21 +32,10 @@ class Modules(object):
         '''
             This function might be called from button links from other pages.
         '''
-
         # Detects if this function is called from button links from another page.
         referrer_page = web.ctx.env.get('HTTP_REFERER', self.URL_THIS_PAGE)
         parts = referrer_page.split("/")
         referrer_page_shortform = "/" + parts[len(parts) - 1]
         # If referred from another page, direct to this page straight away.
         if referrer_page_shortform != self.URL_THIS_PAGE:
-            raise web.seeother(self.URL_THIS_PAGE)
-
-        try:
-            data = web.input()
-            action = data.action  # if action is not 'delete', will trigger AttributeError
-            module_code = data.code
-            outcome = model.delete_module(module_code)
-            return Outcome().POST("delete_module", outcome, module_code)
-
-        except AttributeError:
             raise web.seeother(self.URL_THIS_PAGE)

--- a/components/handlers/outcome.py
+++ b/components/handlers/outcome.py
@@ -70,10 +70,12 @@ class Outcome(object):
                 if outcome is True:
                     outcome_message = "Module " + module_code + " has been deleted successfully!"
                 else:
-                    outcome_message = "Error: Module " + module_code + " currently has " +\
-                                      "mountings that refer to it or is starred. " +\
-                                      "Remove all mountings and unstar before deleting module!"
-                redirect_page = "/modules"
+                    outcome_message = "Error: Failed to delete module. "
+                    if module_code is not None:
+                        outcome_message += "Module " + module_code + " may have " +\
+                                           "mountings that refer to it or is starred. " +\
+                                           "Remove all mountings and unstar before deleting module!"
+                redirect_page = "/deleteModule"
 
             elif action == "create_user":
                 if outcome is True:

--- a/components/handlers/outcome.py
+++ b/components/handlers/outcome.py
@@ -69,13 +69,20 @@ class Outcome(object):
             elif action == "delete_module":
                 if outcome is True:
                     outcome_message = "Module " + module_code + " has been deleted successfully!"
+                    redirect_page = "/deleteModule"
                 else:
                     outcome_message = "Error: Failed to delete module. "
+                    redirect_page = "/deleteModule"
                     if module_code is not None:
-                        outcome_message += "Module " + module_code + " may have " +\
-                                           "mountings that refer to it or is starred. " +\
-                                           "Remove all mountings and unstar before deleting module!"
-                redirect_page = "/deleteModule"
+                        if outcome == "has_mounting":
+                            outcome_message += "Module " + module_code + " has " +\
+                                               "mountings that refer to it. " +\
+                                               "Please remove all mountings before deleting the module."
+                            redirect_page = "/viewModule?code=" + module_code
+                        elif outcome == "is_starred":
+                            outcome_message += "Module " + module_code + " is a starred module. " +\
+                                               "Please unstar the module before deleting the module."
+                            redirect_page = "/viewModule?code=" + module_code
 
             elif action == "create_user":
                 if outcome is True:

--- a/components/model.py
+++ b/components/model.py
@@ -34,6 +34,10 @@ def get_original_module_info(code):
     return database.get_original_module_info(code)
 
 
+def get_new_modules():
+    return database.get_new_modules()
+
+
 ######################################################################################
 # Functions that add/modify/delete general module information
 ######################################################################################

--- a/static/javascripts/csmodify.js
+++ b/static/javascripts/csmodify.js
@@ -88,6 +88,10 @@ $(function() {
         "aaSorting": []
     } );
 
+    $('#delete-module-table').DataTable( {
+        "aaSorting": []
+    } );
+
     $('#fixed-mounting-table').DataTable( {
         "aaSorting": []
     } );

--- a/static/stylesheets/csmodify.css
+++ b/static/stylesheets/csmodify.css
@@ -419,9 +419,9 @@ tr[id*='modified-details-child-row'] {
 /* ==================== General =================== */
 /********************************************************************************/
 .tooltip-inner {
-    max-width: 350px;
+    max-width: 250px;
     /* If max-width does not work, try using width instead */
-    width: 350px; 
+    width: 250px; 
 }
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@ $def with (page)
 					<li><a href="#">Change Preclusions/Prerequisites</a></li>
 					<li><a href="#">Edit Module</a></li-->
 					<li><a id="sidebar" href="/addModule">Add Module</a></li>
-					<!--li><a href="#">Delete Module</a></li-->
+					<li><a id="sidebar" href="/deleteModule">Delete Module</a></li>
 				</ul>
 				<h3 id="sidebar"><span class="glyphicon glyphicon-random"></span>&nbsp;&nbsp;&nbsp;Module Relations</h3>
 				<ul id="sidebar">

--- a/templates/deleteModule.html
+++ b/templates/deleteModule.html
@@ -11,7 +11,7 @@ $var hierarchy = [home, deleteModule]
             <h1 class="text-center"><b>Delete Module</b></h1>
             <p class="text-center">Delete a <b>new module</b> that was added into the system.</p>
             <br>
-            <table class="table table-bordered table-hover display dataTable" id="module-listing-table">
+            <table class="table table-bordered table-hover display dataTable" id="delete-module-table">
                 <thead>
                     <tr>
                         <th>Code</th>
@@ -36,7 +36,7 @@ $var hierarchy = [home, deleteModule]
                         <td class="text-center" style="width:5%;">$moduleMc</td>
                         <td class="text-center" style="width:8%;">
                             <form action="/deleteModule" method="post" onsubmit="if(!confirm('Are you sure you want to delete this module?')){event.preventDefault();}">
-                                <input type="hidden" name="code" value="$moduleInfo[0]">
+                                <input type="hidden" name="code" value="$moduleCode">
                                 <button class="btn btn-primary" type="submit" data-toggle="tooltip" data-placement="bottom" title="Delete Module">
                                     <span class="glyphicon glyphicon-trash"></span>
                                 </button>

--- a/templates/deleteModule.html
+++ b/templates/deleteModule.html
@@ -9,7 +9,12 @@ $var hierarchy = [home, deleteModule]
     <div class="row">
         <div class="col-md-12">
             <h1 class="text-center"><b>Delete Module</b></h1>
-            <p class="text-center">Delete a <b>new module</b> that was added into the system.</p>
+            <p class="text-center">
+                Delete a <b style="color:red;">new module</b>
+                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom"
+                title="Only modules with status 'New' will appear here. Modules with status 'Active' CANNOT be directly deleted from the system"></span>
+                that was added into the system.
+            </p>
             <br>
             <table class="table table-bordered table-hover display dataTable" id="delete-module-table">
                 <thead>

--- a/templates/deleteModule.html
+++ b/templates/deleteModule.html
@@ -1,0 +1,50 @@
+$def with (moduleInfos) 
+
+$var title:Delete Module
+$ home = ['/', 'Home']
+$ deleteModule = ['#', 'Delete Module']
+$var hierarchy = [home, deleteModule]
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h1 class="text-center"><b>Delete Module</b></h1>
+            <p class="text-center">Delete a <b>new module</b> that was added into the system.</p>
+            <br>
+            <table class="table table-bordered table-hover display dataTable" id="module-listing-table">
+                <thead>
+                    <tr>
+                        <th>Code</th>
+                        <th>Name</th>
+                        <th>Description</th>
+                        <th>MCs</th>
+                        <th data-sortable="false">Delete</th>
+                    </tr>
+                </thead>
+                <tbody>
+                $for moduleInfo in moduleInfos:
+                    <tr>
+                    $ moduleCode = moduleInfo[0]
+                    $ moduleName = moduleInfo[1]
+                    $ moduleDesc = moduleInfo[2] 
+                    $ moduleMc = moduleInfo[3] 
+                        <td class="text-center" style="width:8%;">
+                            <a href="/viewModule?code=$moduleCode" target="_blank" data-toggle="tooltip" title="View general info for $moduleCode">$moduleCode</a>
+                        </td>
+                        <td>$moduleName</td>
+                        <td>$moduleDesc</td>
+                        <td class="text-center" style="width:5%;">$moduleMc</td>
+                        <td class="text-center" style="width:8%;">
+                            <form action="/deleteModule" method="post" onsubmit="if(!confirm('Are you sure you want to delete this module?')){event.preventDefault();}">
+                                <input type="hidden" name="code" value="$moduleInfo[0]">
+                                <button class="btn btn-primary" type="submit" data-toggle="tooltip" data-placement="bottom" title="Delete Module">
+                                    <span class="glyphicon glyphicon-trash"></span>
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/templates/deleteModule.html
+++ b/templates/deleteModule.html
@@ -11,8 +11,8 @@ $var hierarchy = [home, deleteModule]
             <h1 class="text-center"><b>Delete Module</b></h1>
             <p class="text-center">
                 Delete a <b style="color:red;">new module</b>
-                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom"
-                title="Only modules with status 'New' will appear here. Modules with status 'Active' CANNOT be directly deleted from the system"></span>
+                <span class="glyphicon glyphicon-info-sign" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                title="Only showing modules with status 'New'. <br>Modules with status 'Active' CANNOT be directly deleted from the system"></span>
                 that was added into the system.
             </p>
             <br>

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,7 +47,7 @@ $var hierarchy = [home]
                             <li>Change Preclusions/Prerequisites</li>
                             <li>Edit Module</li-->
                             <li><a id="home-page" href="/addModule">Add Module</a></li>
-                            <!--li>Delete Modules</li-->
+                            <li><a id="home-page" href="/deleteModule">Delete Module</a></li>
                         </div>
                     </div>
                 </div>

--- a/templates/moduleListing.html
+++ b/templates/moduleListing.html
@@ -30,33 +30,26 @@ $var hierarchy = [home, moduleInfo]
                         <th>Description</th>
                         <th>MCs</th>
                         <th>Is New Module?</th>
-                        <th data-sortable="false">Actions</th>
                     </tr>
                 </thead>
                 <tbody>
                 $for moduleInfo in moduleInfos:
+                    $ moduleCode = moduleInfo[0]
+                    $ moduleName = moduleInfo[1]
+                    $ moduleDesc = moduleInfo[2] 
+                    $ moduleMc = moduleInfo[3]
+                    $ moduleStatus = moduleInfo[4]
                     <tr>
-                        <td class="text-center">$moduleInfo[0]</td>
-                        <td>$moduleInfo[1]</td>
-                        <td>$moduleInfo[2]</td>
-                        <td class="text-center">$moduleInfo[3]</td>
-                        $if moduleInfo[4][0:3] == 'New':
+                        <td class="text-center">
+                            <a href="/viewModule?code=$moduleCode" target="_blank" data-toggle="tooltip" title="View general info for $moduleCode">$moduleCode</a>
+                        </td>
+                        <td style="width:15%">$moduleName</td>
+                        <td>$moduleDesc</td>
+                        <td class="text-center">$moduleMc</td>
+                        $if moduleStatus[0:3] == 'New':
                             <td class="text-center">Yes</td>
                         $else:
                             <td class="text-center">No</td>
-                        <td>
-                            <form action="/viewModule" method="get">
-                                <input type="hidden" name="code" value="$moduleInfo[0]">
-                                <input class="btn btn-primary" type="submit" value="View Module"/>
-                            </form>
-                            
-                            $if moduleInfo[4][0:3] == 'New':
-                                <form action="/modules" method="post" onsubmit="if(!confirm('Are you sure you want to delete this module?')){event.preventDefault();}">
-                                    <input type="hidden" name="action" value="delete">
-                                    <input type="hidden" name="code" value="$moduleInfo[0]">
-                                    <input class="btn btn-primary" type="submit" value="Delete Module"/>
-                                </form>
-                        </td>
                     </tr>
                 </tbody>
             </table>

--- a/templates/moduleMountingFixed.html
+++ b/templates/moduleMountingFixed.html
@@ -44,19 +44,27 @@ $var hierarchy = [home, fixedMounting]
                             <td>$moduleName</td>
                         $if sem1Mounting == 1:
                             <td>
-                                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+1" target="_blank">
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                </a>
                             </td>
                         $elif sem1Mounting == -1:
                             <td>
-                                <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+1" target="_blank">
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                </a>
                             </td>
                         $if sem2Mounting == 1:
                             <td>
-                                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+2" target="_blank">
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                </a>
                             </td>
                         $elif sem2Mounting == -1:
                             <td>
-                                <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+2" target="_blank">
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                </a>
                             </td>
                         </tr>
                 </tbody>

--- a/templates/moduleMountingFixed.html
+++ b/templates/moduleMountingFixed.html
@@ -45,25 +45,28 @@ $var hierarchy = [home, fixedMounting]
                         $if sem1Mounting == 1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+1" target="_blank">
-                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true" 
+                                    title="Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem1Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+1" target="_blank">
-                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $if sem2Mounting == 1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+2" target="_blank">
-                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
-                                </a>
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
                             </td>
                         $elif sem2Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+2" target="_blank">
-                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         </tr>

--- a/templates/moduleMountingFixed.html
+++ b/templates/moduleMountingFixed.html
@@ -29,37 +29,34 @@ $var hierarchy = [home, fixedMounting]
                         <th>Name</th>
                         <th data-sortable="false">Mounted In Sem 1</th>
                         <th data-sortable="false">Mounted In Sem 2</th>
-                        <th data-sortable="false">Action</th>
                     </tr>
                 </thead>
                 <tbody>
                     $for subplan in fullMountingPlan:
-
+                        $ moduleCode = subplan[0]
+                        $ moduleName = subplan[1]
+                        $ sem1Mounting = subplan[2]
+                        $ sem2Mounting = subplan[3]
                         <tr>
-                            <td>$subplan[0]</td>
-                            <td>$subplan[1]</td>
-                        $if subplan[2] == 1:
+                            <td class="text-center">
+                                <a href="/viewModule?code=$moduleCode" target="_blank" data-toggle="tooltip" title="View general info for $moduleCode">$moduleCode</a>
+                            </td>
+                            <td>$moduleName</td>
+                        $if sem1Mounting == 1:
                             <td>
                                 <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
                             </td>
-                        $elif subplan[2] == -1:
+                        $elif sem1Mounting == -1:
                             <td>
                                 <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
                             </td>
-                        $if subplan[3] == 1:
+                        $if sem2Mounting == 1:
                             <td>
                                 <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
                             </td>
-                        $elif subplan[3] == -1:
+                        $elif sem2Mounting == -1:
                             <td>
                                 <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
-                            </td>
-                        $if True:
-                            <td>
-                                <form action="/viewModule" method="get">
-                                    <input type="hidden" name="code" value="$subplan[0]">
-                                    <input class="btn btn-primary" type="submit" value="View Module"/>
-                                </form>
                             </td>
                         </tr>
                 </tbody>

--- a/templates/moduleMountingFixed.html
+++ b/templates/moduleMountingFixed.html
@@ -46,27 +46,27 @@ $var hierarchy = [home, fixedMounting]
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+1" target="_blank">
                                     <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true" 
-                                    title="Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem1Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+1" target="_blank">
                                     <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $if sem2Mounting == 1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+2" target="_blank">
                                     <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>
                             </td>
                         $elif sem2Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$currentAY+Sem+2" target="_blank">
                                     <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         </tr>

--- a/templates/moduleMountingTentative.html
+++ b/templates/moduleMountingTentative.html
@@ -47,27 +47,39 @@ $var hierarchy = [home, tentativeMounting]
                             <td>$moduleName</td>
                         $if sem1Mounting == 1:
                             <td>
-                                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                </a>
                             </td>
                         $elif sem1Mounting == 0:
                             <td>
-                                <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
+                                    <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
+                                </a>
                             </td>
                         $elif sem1Mounting == -1:
                             <td>
-                                <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                </a>
                             </td>
                         $if sem2Mounting == 1:
                             <td>
-                                <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                </a>
                             </td>
                         $elif sem2Mounting == 0:
                             <td>
-                                <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
+                                    <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
+                                </a>
                             </td>
                         $elif sem2Mounting == -1:
                             <td>
-                                <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                </a>
                             </td>
                         </tr>
                 </tbody>

--- a/templates/moduleMountingTentative.html
+++ b/templates/moduleMountingTentative.html
@@ -32,45 +32,42 @@ $var hierarchy = [home, tentativeMounting]
                         <th>Name</th>
                         <th data-sortable="false">Mounted In Sem 1</th>
                         <th data-sortable="false">Mounted In Sem 2</th>
-                        <th data-sortable="false">Action</th>
                     </tr>
                 </thead>
                 <tbody> 
                     $for subplan in fullMountingPlan:
-
+                        $ moduleCode = subplan[0]
+                        $ moduleName = subplan[1]
+                        $ sem1Mounting = subplan[2]
+                        $ sem2Mounting = subplan[3]
                         <tr>
-                            <td>$subplan[0]</td>
-                            <td>$subplan[1]</td>
-                        $if subplan[2] == 1:
+                            <td class="text-center">
+                                <a href="/viewModule?code=$moduleCode" target="_blank" data-toggle="tooltip" title="View general info for $moduleCode">$moduleCode</a>
+                            </td>
+                            <td>$moduleName</td>
+                        $if sem1Mounting == 1:
                             <td>
                                 <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
                             </td>
-                        $elif subplan[2] == 0:
+                        $elif sem1Mounting == 0:
                             <td>
                                 <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
                             </td>
-                        $elif subplan[2] == -1:
+                        $elif sem1Mounting == -1:
                             <td>
                                 <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
                             </td>
-                        $if subplan[3] == 1:
+                        $if sem2Mounting == 1:
                             <td>
                                 <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
                             </td>
-                        $elif subplan[3] == 0:
+                        $elif sem2Mounting == 0:
                             <td>
                                 <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
                             </td>
-                        $elif subplan[3] == -1:
+                        $elif sem2Mounting == -1:
                             <td>
                                 <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
-                            </td>
-                        $if True:
-                            <td>
-                                <form action="/viewModule" method="get">
-                                    <input type="hidden" name="code" value="$subplan[0]">
-                                    <input class="btn btn-primary" type="submit" value="View Module"/>
-                                </form>
                             </td>
                         </tr>
                 </tbody>

--- a/templates/moduleMountingTentative.html
+++ b/templates/moduleMountingTentative.html
@@ -48,37 +48,43 @@ $var hierarchy = [home, tentativeMounting]
                         $if sem1Mounting == 1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
-                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true" 
+                                    title="Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem1Mounting == 0:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
-                                    <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
+                                    <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" data-html="true" 
+                                    title="Unmounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem1Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
-                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $if sem2Mounting == 1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
-                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" title="Mounted"></span>
+                                    <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true" 
+                                    title="Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem2Mounting == 0:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
-                                    <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" title="Unmounted"></span>
+                                    <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" data-html="true" 
+                                    title="Unmounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem2Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
-                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" title="Not Mounted"></span>
+                                    <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
                                 </a>
                             </td>
                         </tr>

--- a/templates/moduleMountingTentative.html
+++ b/templates/moduleMountingTentative.html
@@ -49,42 +49,42 @@ $var hierarchy = [home, tentativeMounting]
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
                                     <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true" 
-                                    title="Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem1Mounting == 0:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
                                     <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" data-html="true" 
-                                    title="Unmounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Unmounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem1Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+1" target="_blank">
                                     <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $if sem2Mounting == 1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
                                     <span class="glyphicon glyphicon-ok" data-toggle="tooltip" data-placement="bottom" data-html="true" 
-                                    title="Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem2Mounting == 0:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
                                     <span class="glyphicon glyphicon-remove" data-toggle="tooltip" data-placement="bottom" data-html="true" 
-                                    title="Unmounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Unmounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         $elif sem2Mounting == -1:
                             <td>
                                 <a href="/individualModuleInfo?code=$moduleCode&aysem=$selectedAY+Sem+2" target="_blank">
                                     <span class="glyphicon glyphicon-minus" data-toggle="tooltip" data-placement="bottom" data-html="true"
-                                    title="Not Mounted<br>(Click to go to module's AY-Sem view)"></span>
+                                    title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>
                                 </a>
                             </td>
                         </tr>

--- a/test/test_delete_module.py
+++ b/test/test_delete_module.py
@@ -1,0 +1,87 @@
+'''
+    test_delete_module.py test the page view of Delete Module
+'''
+from paste.fixture import TestApp
+from nose.tools import assert_equal
+from app import APP
+from components import model
+from components import session
+
+
+class TestCode(object):
+    '''
+        This class runs the test cases to test Delete Module page
+    '''
+    TABLE_HEADER_CODE = '<th>Code</th>'
+    TABLE_HEADER_NAME = '<th>Name</th>'
+    TABLE_HEADER_DESCRIPTION = '<th>Description</th>'
+    TABLE_HEADER_MC = '<th>MCs</th>'
+    TABLE_HEADER_DELETE = '<th data-sortable="false">Delete</th>'
+
+    DUMMY_MODULE_CODE = "DD1001"
+    DUMMY_MODULE_NAME = "Dummy Module 1"
+
+    global_var = None
+
+    def __init__(self):
+        self.middleware = None
+        self.test_app = None
+
+
+    def setUp(self):
+        '''
+            Sets up the 'app.py' fixture
+        '''
+        self.middleware = []
+        self.test_app = TestApp(APP.wsgifunc(*self.middleware))
+        session.set_up(self.test_app)
+
+        model.add_module(self.DUMMY_MODULE_CODE, self.DUMMY_MODULE_NAME, self.DUMMY_MODULE_NAME, 1, "New")
+
+
+    def tearDown(self):
+        '''
+            Tears down 'app.py' fixture and logs out
+        '''
+        session.tear_down(self.test_app)
+
+        model.delete_module(self.DUMMY_MODULE_CODE)
+
+
+    def test_valid_response(self):
+        '''
+            Tests if user can access the index page without request errors.
+        '''
+        root = self.test_app.get('/deleteModule')
+
+        # checks if HTTP response code is 200 (= OK)
+        assert_equal(root.status, 200)
+
+
+    def test_delete_module_table(self):
+        '''
+            Tests if a table displaying a list of deletable modules exist
+        '''
+        root = self.test_app.get('/deleteModule')
+
+        # Checks the existence of the handler for viewing fixed mounting plan
+        root.mustcontain(self.TABLE_HEADER_CODE)
+        root.mustcontain(self.TABLE_HEADER_NAME)
+        root.mustcontain(self.TABLE_HEADER_DESCRIPTION)
+        root.mustcontain(self.TABLE_HEADER_MC)
+        root.mustcontain(self.TABLE_HEADER_DELETE)
+
+
+    def test_new_module(self):
+        '''
+            Tests if the Delete Module table contains a new module
+        '''
+        root = self.test_app.get('/deleteModule')
+
+        root.mustcontain(self.DUMMY_MODULE_CODE)
+        root.mustcontain(self.DUMMY_MODULE_NAME)
+
+        
+
+
+

--- a/test/test_delete_module.py
+++ b/test/test_delete_module.py
@@ -36,7 +36,8 @@ class TestCode(object):
         self.test_app = TestApp(APP.wsgifunc(*self.middleware))
         session.set_up(self.test_app)
 
-        model.add_module(self.DUMMY_MODULE_CODE, self.DUMMY_MODULE_NAME, self.DUMMY_MODULE_NAME, 1, "New")
+        model.add_module(self.DUMMY_MODULE_CODE, self.DUMMY_MODULE_NAME, self.DUMMY_MODULE_NAME,
+                         1, "New")
 
 
     def tearDown(self):
@@ -80,8 +81,3 @@ class TestCode(object):
 
         root.mustcontain(self.DUMMY_MODULE_CODE)
         root.mustcontain(self.DUMMY_MODULE_NAME)
-
-        
-
-
-

--- a/test/test_module_listing.py
+++ b/test/test_module_listing.py
@@ -28,7 +28,6 @@ class TestCode(object):
     TABLE_HEADER_DESCRIPTION = '<th>Description</th>'
     TABLE_HEADER_MC = '<th>MCs</th>'
     TABLE_HEADER_STATUS = '<th>Is New Module?</th>'
-    TABLE_HEADER_ACTIONS = '<th data-sortable="false">Actions</th>'
 
     global_var = None
 
@@ -152,4 +151,3 @@ class TestCode(object):
         root.mustcontain(self.TABLE_HEADER_DESCRIPTION)
         root.mustcontain(self.TABLE_HEADER_MC)
         root.mustcontain(self.TABLE_HEADER_STATUS)
-        root.mustcontain(self.TABLE_HEADER_ACTIONS)

--- a/test/test_module_mounting_fixed.py
+++ b/test/test_module_mounting_fixed.py
@@ -51,14 +51,14 @@ class TestCode(object):
     TABLE_HEADER_MOUNTING_SEM_2 = '<th data-sortable="false">' +\
                                   'Mounted In Sem 2</th>'
     TABLE_MOUNTING_SYMBOL_MOUNTED = '<span class="glyphicon glyphicon-ok" ' +\
-                                    'data-toggle="tooltip" data-placement="bottom" ' +\
-                                    'title="Mounted"></span>'
+                                    'data-toggle="tooltip" data-placement="bottom" data-html="true" ' +\
+                                    'title="Mounted<br>(Click to go to module AY-Sem view)"></span>'
     TABLE_MOUNTING_SYMBOL_UNMOUNTED = '<span class="glyphicon glyphicon-remove" ' +\
-                                      'data-toggle="tooltip" data-placement="bottom' +\
-                                      '" title="Unmounted"></span>'
+                                      'data-toggle="tooltip" data-placement="bottom" data-html="true" ' +\
+                                    'title="Unmounted<br>(Click to go to module AY-Sem view)"></span>'
     TABLE_MOUNTING_SYMBOL_NOT_MOUNTED = '<span class="glyphicon glyphicon-minus" ' +\
-                                        'data-toggle="tooltip" data-placement="' +\
-                                        'bottom" title="Not Mounted"></span>'
+                                        'data-toggle="tooltip" data-placement="bottom" data-html="true" ' +\
+                                        'title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>'
 
 
     def __init__(self):

--- a/test/test_module_mounting_fixed.py
+++ b/test/test_module_mounting_fixed.py
@@ -50,7 +50,6 @@ class TestCode(object):
                                   'Mounted In Sem 1</th>'
     TABLE_HEADER_MOUNTING_SEM_2 = '<th data-sortable="false">' +\
                                   'Mounted In Sem 2</th>'
-    TABLE_HEADER_ACTION = '<th data-sortable="false">Action</th>'
     TABLE_MOUNTING_SYMBOL_MOUNTED = '<span class="glyphicon glyphicon-ok" ' +\
                                     'data-toggle="tooltip" data-placement="bottom" ' +\
                                     'title="Mounted"></span>'
@@ -161,6 +160,5 @@ class TestCode(object):
         root.mustcontain(self.TABLE_HEADER_NAME)
         root.mustcontain(self.TABLE_HEADER_MOUNTING_SEM_1)
         root.mustcontain(self.TABLE_HEADER_MOUNTING_SEM_2)
-        root.mustcontain(self.TABLE_HEADER_ACTION)
         root.mustcontain(self.TABLE_MOUNTING_SYMBOL_MOUNTED)
         root.mustcontain(self.TABLE_MOUNTING_SYMBOL_NOT_MOUNTED)

--- a/test/test_module_mounting_tentative.py
+++ b/test/test_module_mounting_tentative.py
@@ -50,14 +50,14 @@ class TestCode(object):
     TABLE_HEADER_MOUNTING_SEM_2 = '<th data-sortable="false">' +\
                                   'Mounted In Sem 2</th>'
     TABLE_MOUNTING_SYMBOL_MOUNTED = '<span class="glyphicon glyphicon-ok" ' +\
-                                    'data-toggle="tooltip" data-placement="bottom" ' +\
-                                    'title="Mounted"></span>'
+                                    'data-toggle="tooltip" data-placement="bottom" data-html="true" ' +\
+                                    'title="Mounted<br>(Click to go to module AY-Sem view)"></span>'
     TABLE_MOUNTING_SYMBOL_UNMOUNTED = '<span class="glyphicon glyphicon-remove" ' +\
-                                      'data-toggle="tooltip" data-placement="bottom' +\
-                                      '" title="Unmounted"></span>'
+                                      'data-toggle="tooltip" data-placement="bottom" data-html="true" ' +\
+                                    'title="Unmounted<br>(Click to go to module AY-Sem view)"></span>'
     TABLE_MOUNTING_SYMBOL_NOT_MOUNTED = '<span class="glyphicon glyphicon-minus" ' +\
-                                        'data-toggle="tooltip" data-placement="' +\
-                                        'bottom" title="Not Mounted"></span>'
+                                        'data-toggle="tooltip" data-placement="bottom" data-html="true" ' +\
+                                        'title="Not Mounted<br>(Click to go to module AY-Sem view)"></span>'
 
 
     def __init__(self):

--- a/test/test_module_mounting_tentative.py
+++ b/test/test_module_mounting_tentative.py
@@ -49,7 +49,6 @@ class TestCode(object):
                                   'Mounted In Sem 1</th>'
     TABLE_HEADER_MOUNTING_SEM_2 = '<th data-sortable="false">' +\
                                   'Mounted In Sem 2</th>'
-    TABLE_HEADER_ACTION = '<th data-sortable="false">Action</th>'
     TABLE_MOUNTING_SYMBOL_MOUNTED = '<span class="glyphicon glyphicon-ok" ' +\
                                     'data-toggle="tooltip" data-placement="bottom" ' +\
                                     'title="Mounted"></span>'
@@ -153,6 +152,5 @@ class TestCode(object):
         root.mustcontain(self.TABLE_HEADER_NAME)
         root.mustcontain(self.TABLE_HEADER_MOUNTING_SEM_1)
         root.mustcontain(self.TABLE_HEADER_MOUNTING_SEM_2)
-        root.mustcontain(self.TABLE_HEADER_ACTION)
         root.mustcontain(self.TABLE_MOUNTING_SYMBOL_MOUNTED)
         root.mustcontain(self.TABLE_MOUNTING_SYMBOL_NOT_MOUNTED)


### PR DESCRIPTION
What's new in this branch:
* Created Delete Module page (Issue #70) and removed delete buttons from module listing.
* Replaced view buttons with module code hyperlinks (for module listing, fixed mounting and tentative mounting pages)
* Added hyperlinks to the mounting icons in fixed/tentative mounting (on click, will open the ay sem view in a new tab)
